### PR TITLE
[UI] improve monitor for devices under 1200px

### DIFF
--- a/src/css/monitor.css
+++ b/src/css/monitor.css
@@ -307,8 +307,7 @@ a#fern {
 
 @media (max-width: 1200px) {
     .view {
-        height: auto;
-        overflow: visible;
+        height: 100vh;
     }
     #logo img {
         width: 90%;

--- a/src/css/monitor.css
+++ b/src/css/monitor.css
@@ -304,3 +304,35 @@ a#fern {
     white-space: nowrap;
     line-height: 1;
 }
+
+@media (max-width: 1200px) {
+    .view {
+        height: auto;
+        overflow: visible;
+    }
+    #logo img {
+        width: 90%;
+        height: auto;
+    }
+    #clock {
+        font-size: 3.5em;
+    }
+    #date {
+        font-size: 1.25em;
+    }
+    .einsatzinfo h1 {
+        font-size: 1.2rem;
+    }
+    .einsatzinfo h3 {
+        font-size: 1rem;
+    }
+    .weather-data h1 {
+        font-size: 3rem;
+    }
+    .weather-data h3 {
+        font-size: 1.2rem;
+    }
+    .personal-box a {
+        font-size: 1.75em;
+    }
+}


### PR DESCRIPTION
This pull request introduces a responsive design improvement to the monitor display by adding a media query for screens with a maximum width of 1200px. The styles within this media query adjust the sizing of various elements to ensure better usability and readability on smaller screens.

Responsive design adjustments for smaller screens:

* Added a `@media (max-width: 1200px)` block to `monitor.css` to:
  * Set `.view` height to `100vh`
  * Scale down the logo image size
  * Reduce font sizes for `#clock`, `#date`, `.einsatzinfo h1`, `.einsatzinfo h3`, `.weather-data h1`, `.weather-data h3`, and `.personal-box a`